### PR TITLE
Fix: scroll bar on status indicator + edit link

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -65,7 +65,7 @@ export default async function RootLayout({ children }) {
           banner={banner}
           navbar={navbar}
           pageMap={await getPageMap()}
-          docsRepositoryBase="https://github.com/confident-ai/confident-docs/tree/main/docs"
+          docsRepositoryBase="https://github.com/confident-ai/confident-docs/tree/main"
           footer={footer}
         >
           {children}

--- a/components/CustomFooter/CustomFooter.jsx
+++ b/components/CustomFooter/CustomFooter.jsx
@@ -23,8 +23,8 @@ const CustomFooter = () => {
                 className={styles.statusBadge}
                 src="https://status.confident-ai.com/badge?theme=dark" 
                 width="182" 
-                height="30"
-                style={{backgroundColor: 'black', borderRadius: '10px'}}
+                height="31"
+                style={{backgroundColor: 'black', borderRadius: '10px', overflow: 'hidden'}}
                 title="Confident AI Status"
               />
             </div>

--- a/content/getting-started/run-an-evaluation.mdx
+++ b/content/getting-started/run-an-evaluation.mdx
@@ -10,7 +10,7 @@ Let's run your first **end-to-end** evaluation and create a [test run](/concepts
 
 <details>
 
-<summary>WHat is end-to-end evaluation?</summary>
+<summary>What is end-to-end evaluation?</summary>
 
 [End-to-end evaluation](/llm-evaluation/run-evals/end-to-end-evals) refers to LLM evaluation where your LLM application is treated as a black-box, and only the system inputs and outputs are taken into account. When running end-to-end evaluations, you should only create test cases from the `input`s, `actual_outputs`s, and any other overarching parameter of your LLM system.
 


### PR DESCRIPTION
## Description

- Removes the scroll bar on the status indicator iframe
Before:
<img width="228" alt="Screenshot 2025-06-03 at 21 12 01" src="https://github.com/user-attachments/assets/7137b251-bf62-4ae4-89a4-88006d863a5d" />
After:
<img width="224" alt="Screenshot 2025-06-03 at 21 12 33" src="https://github.com/user-attachments/assets/b3b4932d-c03f-4cfe-bd57-d57e869c2551" />

- Fixes the "Edit this page" URL to point to the github mdx page instead of 404ing