### PR TITLE
Adding a copy markdown button that enables users to copy a documentation page in .md format

### DIFF
--- a/app/[[...mdxPath]]/page.jsx
+++ b/app/[[...mdxPath]]/page.jsx
@@ -1,6 +1,7 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages'
 import { useMDXComponents as getMDXComponents } from "../../mdx-components"
 import { redirect } from 'next/navigation' 
+import { PageParamsProvider } from '../../components/PageParamsContext'
 
 export const generateStaticParams = generateStaticParamsFor('mdxPath')
  
@@ -32,7 +33,9 @@ export default async function Page(props) {
   const { default: MDXContent, toc, metadata } = result
   return (
     <Wrapper toc={toc} metadata={metadata}>
-      <MDXContent {...props} params={params} />
+      <PageParamsProvider value={params}>
+        <MDXContent {...props} params={params} />
+      </PageParamsProvider>
     </Wrapper>
   )
 }

--- a/app/api/raw-mdx/route.js
+++ b/app/api/raw-mdx/route.js
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { NextResponse } from 'next/server'
+
+const CONTENT_ROOT = path.join(process.cwd(), 'content')
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url)
+  const relPath = searchParams.get('path')
+  if (!relPath) {
+    return NextResponse.json({ error: 'Missing path parameter' }, { status: 400 })
+  }
+  // Only allow .mdx files and prevent path traversal
+  const safePath = path.normalize(relPath).replace(/^\/+|\/+$/g, '')
+  if (safePath.includes('..')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+  const filePath = path.join(CONTENT_ROOT, `${safePath}.mdx`)
+  try {
+    const content = await fs.readFile(filePath, 'utf8')
+    return new NextResponse(content, {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  } catch (err) {
+    return NextResponse.json({ error: 'File not found' }, { status: 404 })
+  }
+} 

--- a/components/CopyMarkdownButton/index.jsx
+++ b/components/CopyMarkdownButton/index.jsx
@@ -1,0 +1,49 @@
+"use client"
+import React from "react"
+
+export default function CopyMarkdownButton({ pagePath }) {
+  const [copied, setCopied] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState(null)
+
+  const handleCopy = async () => {
+    if (!pagePath) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/raw-mdx?path=${encodeURIComponent(pagePath)}`)
+      if (!res.ok) throw new Error('Failed to fetch markdown')
+      const markdown = await res.text()
+      await navigator.clipboard.writeText(markdown)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1200)
+    } catch (err) {
+      setError('Error copying markdown')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      style={{
+        position: 'absolute',
+        right: 0,
+        top: '-2.5rem',
+        fontSize: '0.85rem',
+        padding: '0.3rem 0.7rem',
+        background: '#f3f3f3',
+        border: '1px solid #ccc',
+        borderRadius: '6px',
+        cursor: loading ? 'wait' : 'pointer',
+        zIndex: 2
+      }}
+      aria-label="Copy markdown"
+      disabled={loading}
+    >
+      {loading ? 'Loading...' : copied ? 'Copied!' : 'Copy markdown'}
+      {error && <span style={{ color: 'red', marginLeft: 8 }}>{error}</span>}
+    </button>
+  )
+} 

--- a/components/H1WithCopy/index.jsx
+++ b/components/H1WithCopy/index.jsx
@@ -1,0 +1,18 @@
+"use client";
+import React from "react";
+import { usePageParams } from "../PageParamsContext";
+import CopyMarkdownButton from "../CopyMarkdownButton";
+
+export default function H1WithCopy({ children, ...props }) {
+  const params = usePageParams();
+  let pagePath = "";
+  if (params?.mdxPath && Array.isArray(params.mdxPath)) {
+    pagePath = params.mdxPath.join("/");
+  }
+  return (
+    <div style={{ position: "relative", marginBottom: "1.5rem" }}>
+      <CopyMarkdownButton pagePath={pagePath} />
+      <h1 {...props}>{children}</h1>
+    </div>
+  );
+} 

--- a/components/PageParamsContext.jsx
+++ b/components/PageParamsContext.jsx
@@ -1,0 +1,13 @@
+"use client";
+import React, { createContext, useContext } from "react";
+
+const PageParamsContext = createContext({});
+export const usePageParams = () => useContext(PageParamsContext);
+
+export function PageParamsProvider({ value, children }) {
+  return (
+    <PageParamsContext.Provider value={value}>
+      {children}
+    </PageParamsContext.Provider>
+  );
+} 

--- a/mdx-components.js
+++ b/mdx-components.js
@@ -4,6 +4,7 @@ import VideoDisplayer from './components/VideoDisplayer'
 import ImageDisplayer from './components/ImageDisplayer'
 import SignUpButton from './components/SignUpButton'
 import NavIconTabItem from './components/NavIconTabItem'
+import H1WithCopy from './components/H1WithCopy'
  
 // Get the default MDX components
 const themeComponents = getThemeComponents()
@@ -12,6 +13,7 @@ const themeComponents = getThemeComponents()
 export function useMDXComponents(components) {
   return {
     ...themeComponents,
+    h1: H1WithCopy,
     ComparisonTable,
     VideoDisplayer,
     ImageDisplayer,


### PR DESCRIPTION
<img width="1511" alt="Screenshot 2025-06-28 at 5 58 14 PM" src="https://github.com/user-attachments/assets/dc793714-5b8c-4232-83f7-a71e6bd196da" />

--------------

To test: 
1. `yarn dev`
2. Click the copy markdown button on top right. 