### PR TITLE
Aditya/fix markdown button

### DIFF
--- a/app/[[...mdxPath]]/page.jsx
+++ b/app/[[...mdxPath]]/page.jsx
@@ -1,6 +1,7 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages'
 import { useMDXComponents as getMDXComponents } from "../../mdx-components"
 import { redirect } from 'next/navigation' 
+import { PageParamsProvider } from '../../components/PageParamsContext'
 
 export const generateStaticParams = generateStaticParamsFor('mdxPath')
  
@@ -32,7 +33,9 @@ export default async function Page(props) {
   const { default: MDXContent, toc, metadata } = result
   return (
     <Wrapper toc={toc} metadata={metadata}>
-      <MDXContent {...props} params={params} />
+      <PageParamsProvider value={params}>
+        <MDXContent {...props} params={params} />
+      </PageParamsProvider>
     </Wrapper>
   )
 }

--- a/app/api/raw-mdx/route.js
+++ b/app/api/raw-mdx/route.js
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { NextResponse } from 'next/server'
+
+const CONTENT_ROOT = path.join(process.cwd(), 'content')
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url)
+  const relPath = searchParams.get('path')
+  if (!relPath) {
+    return NextResponse.json({ error: 'Missing path parameter' }, { status: 400 })
+  }
+  // Only allow .mdx files and prevent path traversal
+  const safePath = path.normalize(relPath).replace(/^\/+|\/+$/g, '')
+  if (safePath.includes('..')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+  const filePath = path.join(CONTENT_ROOT, `${safePath}.mdx`)
+  try {
+    const content = await fs.readFile(filePath, 'utf8')
+    return new NextResponse(content, {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  } catch (err) {
+    return NextResponse.json({ error: 'File not found' }, { status: 404 })
+  }
+} 

--- a/components/CopyMarkdownButton/index.jsx
+++ b/components/CopyMarkdownButton/index.jsx
@@ -6,18 +6,56 @@ export default function CopyMarkdownButton({ pagePath }) {
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState(null)
 
+  const copyToClipboard = async (text) => {
+    // Check if clipboard API is available
+    if (navigator.clipboard && window.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(text)
+        return true
+      } catch (err) {
+        console.warn('Clipboard API failed:', err)
+        // Fall through to fallback method
+      }
+    }
+    
+    // Fallback: use document.execCommand
+    try {
+      const textArea = document.createElement('textarea')
+      textArea.value = text
+      textArea.style.position = 'fixed'
+      textArea.style.left = '-999999px'
+      textArea.style.top = '-999999px'
+      document.body.appendChild(textArea)
+      textArea.focus()
+      textArea.select()
+      const successful = document.execCommand('copy')
+      document.body.removeChild(textArea)
+      return successful
+    } catch (err) {
+      console.error('Fallback copy failed:', err)
+      return false
+    }
+  }
+
   const handleCopy = async () => {
     if (!pagePath) return
     setLoading(true)
     setError(null)
     try {
+      console.log("Looking for file at " + pagePath)
       const res = await fetch(`/api/raw-mdx?path=${encodeURIComponent(pagePath)}`)
       if (!res.ok) throw new Error('Failed to fetch markdown')
       const markdown = await res.text()
-      await navigator.clipboard.writeText(markdown)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1200)
+      
+      const success = await copyToClipboard(markdown)
+      if (success) {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1200)
+      } else {
+        setError('Failed to copy to clipboard')
+      }
     } catch (err) {
+      console.log("See the error" + err)
       setError('Error copying markdown')
     } finally {
       setLoading(false)
@@ -30,7 +68,7 @@ export default function CopyMarkdownButton({ pagePath }) {
       style={{
         position: 'absolute',
         right: 0,
-        top: '-2.5rem',
+        top: '-1.5rem',
         fontSize: '0.85rem',
         padding: '0.3rem 0.7rem',
         background: '#f3f3f3',
@@ -46,4 +84,4 @@ export default function CopyMarkdownButton({ pagePath }) {
       {error && <span style={{ color: 'red', marginLeft: 8 }}>{error}</span>}
     </button>
   )
-} 
+}

--- a/components/CopyMarkdownButton/index.jsx
+++ b/components/CopyMarkdownButton/index.jsx
@@ -1,0 +1,49 @@
+"use client"
+import React from "react"
+
+export default function CopyMarkdownButton({ pagePath }) {
+  const [copied, setCopied] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState(null)
+
+  const handleCopy = async () => {
+    if (!pagePath) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/raw-mdx?path=${encodeURIComponent(pagePath)}`)
+      if (!res.ok) throw new Error('Failed to fetch markdown')
+      const markdown = await res.text()
+      await navigator.clipboard.writeText(markdown)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1200)
+    } catch (err) {
+      setError('Error copying markdown')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      style={{
+        position: 'absolute',
+        right: 0,
+        top: '-2.5rem',
+        fontSize: '0.85rem',
+        padding: '0.3rem 0.7rem',
+        background: '#f3f3f3',
+        border: '1px solid #ccc',
+        borderRadius: '6px',
+        cursor: loading ? 'wait' : 'pointer',
+        zIndex: 2
+      }}
+      aria-label="Copy markdown"
+      disabled={loading}
+    >
+      {loading ? 'Loading...' : copied ? 'Copied!' : 'Copy markdown'}
+      {error && <span style={{ color: 'red', marginLeft: 8 }}>{error}</span>}
+    </button>
+  )
+} 

--- a/components/H1WithCopy/index.jsx
+++ b/components/H1WithCopy/index.jsx
@@ -1,0 +1,18 @@
+"use client";
+import React from "react";
+import { usePageParams } from "../PageParamsContext";
+import CopyMarkdownButton from "../CopyMarkdownButton";
+
+export default function H1WithCopy({ children, ...props }) {
+  const params = usePageParams();
+  let pagePath = "";
+  if (params?.mdxPath && Array.isArray(params.mdxPath)) {
+    pagePath = params.mdxPath.join("/");
+  }
+  return (
+    <div style={{ position: "relative", marginBottom: "1.5rem" }}>
+      <CopyMarkdownButton pagePath={pagePath} />
+      <h1 {...props}>{children}</h1>
+    </div>
+  );
+} 

--- a/components/H1WithCopy/index.jsx
+++ b/components/H1WithCopy/index.jsx
@@ -5,14 +5,17 @@ import CopyMarkdownButton from "../CopyMarkdownButton";
 
 export default function H1WithCopy({ children, ...props }) {
   const params = usePageParams();
+  console.log("H1WithCopy - params:", params);
+  
   let pagePath = "";
   if (params?.mdxPath && Array.isArray(params.mdxPath)) {
     pagePath = params.mdxPath.join("/");
   }
+  console.log("H1WithCopy - pagePath:", pagePath);
+  
   return (
-    <div style={{ position: "relative", marginBottom: "1.5rem" }}>
-      <CopyMarkdownButton pagePath={pagePath} />
-      <h1 {...props}>{children}</h1>
-    </div>
-  );
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.5rem', position: 'relative' }}>
+    <h1 {...props}>{children}</h1>
+    <CopyMarkdownButton pagePath={pagePath} />
+  </div>  );
 } 

--- a/components/PageParamsContext.jsx
+++ b/components/PageParamsContext.jsx
@@ -1,0 +1,13 @@
+"use client";
+import React, { createContext, useContext } from "react";
+
+const PageParamsContext = createContext({});
+export const usePageParams = () => useContext(PageParamsContext);
+
+export function PageParamsProvider({ value, children }) {
+  return (
+    <PageParamsContext.Provider value={value}>
+      {children}
+    </PageParamsContext.Provider>
+  );
+} 

--- a/mdx-components.js
+++ b/mdx-components.js
@@ -4,6 +4,7 @@ import VideoDisplayer from './components/VideoDisplayer'
 import ImageDisplayer from './components/ImageDisplayer'
 import SignUpButton from './components/SignUpButton'
 import NavIconTabItem from './components/NavIconTabItem'
+import H1WithCopy from './components/H1WithCopy'
  
 // Get the default MDX components
 const themeComponents = getThemeComponents()
@@ -12,6 +13,7 @@ const themeComponents = getThemeComponents()
 export function useMDXComponents(components) {
   return {
     ...themeComponents,
+    h1: H1WithCopy,
     ComparisonTable,
     VideoDisplayer,
     ImageDisplayer,


### PR DESCRIPTION
Fixes this PR: https://github.com/confident-ai/confident-docs/pull/28

Issue: 
* specifically for the /docs page, the API call when clicking the "copy markdown" button was happening with path=docs, whereas the actual markdown was at content/docs/index.mdx. 
* Thus the API was returning an error response. 

Fix: 
We look for both the direct file & the index file & try to read them. We return the first one that can be read from the file. 

To test:

yarn dev
Click the copy markdown button on top right. Your clipboard will contain the copied text 