### PR TITLE
Syntax correction during GEval creation

### DIFF
--- a/content/docs/llm-evaluation/introduction.mdx
+++ b/content/docs/llm-evaluation/introduction.mdx
@@ -81,7 +81,7 @@ from deepeval.metrics import GEval
 
 metric = GEval(
   name="Relevancy",
-  criteria="Determine how relevant the 'actual output' is to the 'input'"
+  criteria="Determine how relevant the 'actual output' is to the 'input'",
   evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT]
 )
 ```


### PR DESCRIPTION
The `criteria` parameter is missing a comma after the string, which causes a syntax error.