### PR TITLE
Fix typo in LLM evaluation documentation

### DIFF
--- a/fern/docs/pages/llm-evaluation/core-concepts/llm-as-a-judge-metrics.mdx
+++ b/fern/docs/pages/llm-evaluation/core-concepts/llm-as-a-judge-metrics.mdx
@@ -106,7 +106,7 @@ Single-output LLM-as-a-judge refers to evaluating an LLM output based solely on 
   the two scores to work out if there are any regressions or not.
 </Tip>
 
-#### Refernceless
+#### Referenceless
 
 Referenceless single-output judges simply means there are no labelled, expected output/outcome for your LLM judge to anchor as the ideal output. This is perfect for those that:
 


### PR DESCRIPTION
Corrected the spelling of 'Refernceless' to 'Referenceless' in the documentation.