### PR TITLE
Remove 'actual_output' parameter from tool correctness

### DIFF
--- a/fern/docs/pages/metrics/all-metrics/single-turn/tool-correctness.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/tool-correctness.mdx
@@ -22,9 +22,6 @@ These are the parameters you must supply in your test case to run evaluations fo
 <ParamField path="input" type="string" required>
   The input supplied to your LLM agent.
 </ParamField>
-<ParamField path="actual_output" type="string" required>
-  The final output your LLM agent generated for the given input.
-</ParamField>
 <ParamField path="tools_called" type="list" required>
   A list of the tools called by your LLM agent in the order of their calling in a `ToolCall` instance.
 </ParamField>


### PR DESCRIPTION
Removed the 'actual_output' parameter field from the documentation.