### PR TITLE
docs(fix): typescript imports

### DIFF
--- a/fern/docs/pages/human-in-the-loop/collect-feedback.mdx
+++ b/fern/docs/pages/human-in-the-loop/collect-feedback.mdx
@@ -100,7 +100,7 @@ def llm_app(query: str) -> str:
 
 ```typescript Trace {5,14,15} maxLines={24}
 import { OpenAI } from "openai";
-import { observe, getCurrentTrace } from "deepeval-ts";
+import { observe, getCurrentTrace } from "deepeval-ts/tracing";
 
 const client = new OpenAI();
 let TRACE_UUID: string | null = null;
@@ -125,7 +125,7 @@ const observedLlmApp = observe({ fn: llm_app });
 
 ```typescript Span {5,14,15} maxLines={24}
 import { OpenAI } from "openai";
-import { observe, getCurrentSpan } from "deepeval-ts";
+import { observe, getCurrentSpan } from "deepeval-ts/tracing";
 
 const client = new OpenAI();
 let SPAN_UUID: string | null = null;
@@ -278,7 +278,7 @@ def llm_app(query: str) -> str:
 
 ```typescript index.ts {5,12} maxLines={24}
 import { OpenAI } from "openai";
-import { observe, updateCurrentTrace } from "deepeval-ts";
+import { observe, updateCurrentTrace } from "deepeval-ts/tracing";
 
 const client = new OpenAI();
 const THREAD_ID = "YOUR-THREAD-ID";

--- a/fern/docs/pages/llm-evaluation/dataset-management/using-datasets.mdx
+++ b/fern/docs/pages/llm-evaluation/dataset-management/using-datasets.mdx
@@ -117,8 +117,7 @@ console.log(dataset.goldens);
 Then loop through your dataset of goldens to create a list of test cases:
 
 ```ts index.ts focus={7-13}
-import { EvaluationDataset } from "deepeval-ts";
-import { LLMTestCase } from "deepeval-ts";
+import { EvaluationDataset, LLMTestCase } from "deepeval-ts";
 
 dataset = new EvaluationDataset();
 dataset.pull({ alias: "YOUR-DATASET-ALIAS" });

--- a/fern/docs/pages/llm-tracing/advanced-features/attributes.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/attributes.mdx
@@ -32,13 +32,13 @@ These functions update the attributes for the **CURRENT** span of the component 
     <Tab title="Python" language="python">
             ```python title="main.py" {10}
             from deepeval.tracing import observe, update_retriever_span
-            
+
             @observe(type="custom")
             def outer_function():
-            
+
                 @observe(type="retriever")
                 def inner_function():
-            
+
                     # Here, update_retriever_span() will update the Retriever span
                     update_retriever_span(
                         embedder="text-embedding-ada-002",
@@ -48,7 +48,7 @@ These functions update the attributes for the **CURRENT** span of the component 
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```js title="index.ts" {10}
-            import { observe, updateRetrieverSpan } from "@deepeval-ts/tracing";
+            import { observe, updateRetrieverSpan } from "deepeval-ts/tracing";
 
             const observedOuterFunction = observe({
                 fn: () => {
@@ -111,7 +111,7 @@ LLM attributes track the model, prompt, and token usage and costs of language mo
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {5}
-            import { observe, updateLlmSpan } from '@deepeval-ts/tracing';
+            import { observe, updateLlmSpan } from 'deepeval-ts/tracing';
 
             const generateResponse = (prompt: string) => {
                 const output = "Generated response";
@@ -173,7 +173,7 @@ Retriever attributes track the `embedder`, `top_k`, and `chunk_size` in RAG pipe
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {5}
-            import { observe, updateRetrieverSpan } from '@deepeval-ts/tracing';
+            import { observe, updateRetrieverSpan } from 'deepeval-ts/tracing';
 
             const retrieveDocuments = (query: string): string[] => {
                 const fetchedDocuments = ["doc1", "doc2"];

--- a/fern/docs/pages/llm-tracing/advanced-features/environment.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/environment.mdx
@@ -43,7 +43,7 @@ Alternatively, you can set the environment directly in code:
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {4}
             import OpenAI from 'openai';
-            import { observe, traceManager } from '@deepeval-ts/tracing';
+            import { observe, traceManager } from 'deepeval-ts/tracing';
 
             traceManager.configure({ environment: "production" });
             const openai = new OpenAI();

--- a/fern/docs/pages/llm-tracing/advanced-features/input-output.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/input-output.mdx
@@ -35,7 +35,7 @@ You can set the `input` and `output` of a trace using the `update_current_trace`
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {11}
             import OpenAI from 'openai';
-            import { observe, updateCurrentTrace } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentTrace } from 'deepeval-ts/tracing';
             
             const openai = new OpenAI();
             
@@ -97,7 +97,7 @@ For example, the `"retriever"` span `type` expects a string as the `input` and l
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {11}
             import OpenAI from 'openai';
-            import { observe, updateCurrentSpan } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentSpan } from 'deepeval-ts/tracing';
 
             const openai = new OpenAI();
 

--- a/fern/docs/pages/llm-tracing/advanced-features/masking.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/masking.mdx
@@ -37,7 +37,7 @@ To implement masking, you need to define a masking function and configure the tr
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {9}
-            import { observe, traceManager } from '@deepeval-ts/tracing';
+            import { observe, traceManager } from 'deepeval-ts/tracing';
 
             const maskingFunction = (data: any): any => {
                 if (typeof data === 'string')

--- a/fern/docs/pages/llm-tracing/advanced-features/metadata.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/metadata.mdx
@@ -44,7 +44,7 @@ Each metadata argument is a dictionary whose keys are strings and whose values a
     <Tab title="TypeScript" language="typescript">
         <CodeBlock>
             ```typescript title="index.ts" {6,14}
-            import { observe, updateCurrentSpan, updateCurrentTrace } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentSpan, updateCurrentTrace } from 'deepeval-ts/tracing';
             
             const llmApp = (query: string) => {
                 // Add span-level metadata

--- a/fern/docs/pages/llm-tracing/advanced-features/name.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/name.mdx
@@ -33,7 +33,7 @@ You can name a trace at runtime by providing the `name` paramter in `update_curr
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {7}
             import OpenAI from 'openai';
-            import { observe, updateCurrentTrace } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentTrace } from 'deepeval-ts/tracing';
 
             const openai = new OpenAI();
 
@@ -81,7 +81,7 @@ The default name for a span is the name of the function/method you're decorating
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {7}
             import OpenAI from 'openai';
-            import { observe, updateCurrentSpan } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentSpan } from 'deepeval-ts/tracing';
 
             const openai = new OpenAI();
 

--- a/fern/docs/pages/llm-tracing/advanced-features/sampling.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/sampling.mdx
@@ -43,7 +43,7 @@ Alternatively, you can set the sampling rate directly in code:
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {5}
-            import { observe, traceManager } from '@deepeval-ts/tracing';
+            import { observe, traceManager } from 'deepeval-ts/tracing';
             import OpenAI from 'openai';
 
             const openai = new OpenAI();

--- a/fern/docs/pages/llm-tracing/advanced-features/span-types.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/span-types.mdx
@@ -34,7 +34,7 @@ The most flexible `type` out of all (and the default type if `type` is not provi
     </Tab>
     <Tab title="TypeScript" language="typescript">
         ```typescript
-        import { observe } from '@deepeval-ts/tracing';
+        import { observe } from 'deepeval-ts/tracing';
         
         const ragPipeline = (query: string): string => {
             // Implementation
@@ -83,13 +83,13 @@ An LLM span represents a call to a language model. It tracks the input, output, 
     </Tab>
     <Tab title="TypeScript" language="typescript">
         ```typescript title="index.ts"
-        import { observe } from '@deepeval-ts/tracing';
-        
+        import { observe } from 'deepeval-ts/tracing';
+
         const generateResponse = (prompt: string): string => {
             // Implementation
             return "";
         };
-        
+
         const observedGenerateResponse = observe({
             type: "llm",
             model: "gpt-4",
@@ -105,7 +105,7 @@ An LLM span represents a call to a language model. It tracks the input, output, 
         - [Optional] `costPerOutputToken`: A float specifying the cost per output token. Defaulted to None.
         - [Optional] `name`: A string specifying the display name on Confident AI. Defaulted to the name of the decorated function.
         - [Optional] `metrics` A list of strings specifying the names of the online metrics you wish to run upon tracing to Confident AI. Learn more about using online metrics in the [here](/docs/llm-tracing/evaluations#online-evaluations).
-        
+
     </Tab>
 </Tabs>
 
@@ -123,7 +123,7 @@ A Retriever span represents a component that fetches relevant information from a
         ```python title="main.py"
         from deepeval.tracing import observe
         from typing import List
-        
+
         @observe(type="retriever", embedder="text-embedding-ada-002")
         def retrieve_documents(query: str) -> List[str]:
             pass
@@ -131,13 +131,13 @@ A Retriever span represents a component that fetches relevant information from a
     </Tab>
     <Tab title="TypeScript" language="typescript">
         ```typescript title="index.ts"
-        import { observe } from '@deepeval-ts/tracing';
-        
+        import { observe } from 'deepeval-ts/tracing';
+
         const retrieveDocuments = (query: string): string[] => {
             // Implementation
             return [];
         };
-        
+
         const observedRetrieveDocuments = observe({
             type: "retriever",
             embedder: "text-embedding-ada-002",
@@ -162,7 +162,7 @@ A Tool span represents a function that an agent can call to perform a specific t
     <Tab title="Python" language="python">
         ```python title="main.py"
         from deepeval.tracing import observe
-        
+
         @observe(type="tool")
         def web_search(query: str) -> str:
             pass
@@ -170,13 +170,13 @@ A Tool span represents a function that an agent can call to perform a specific t
     </Tab>
     <Tab title="TypeScript" language="typescript">
         ```typescript title="index.ts"
-        import { observe } from '@deepeval-ts/tracing';
-        
+        import { observe } from 'deepeval-ts/tracing';
+
         const webSearch = (query: string): string => {
             // Implementation
             return "";
         };
-        
+
         const observedWebSearch = observe({
             type: "tool",
             fn: webSearch
@@ -200,7 +200,7 @@ An Agent span represents an autonomous entity that can make decisions and intera
     <Tab title="Python" language="python">
         ```python title="main.py"
         from deepeval.tracing import observe
-        
+
         @observe(
             type="agent",
             available_tools=["search", "calculator"],
@@ -221,13 +221,13 @@ An Agent span represents an autonomous entity that can make decisions and intera
     </Tab>
     <Tab title="TypeScript" language="typescript">
         ```typescript title="index.ts"
-        import { observe } from '@deepeval-ts/tracing';
-        
+        import { observe } from 'deepeval-ts/tracing';
+
         const supervisorAgent = (query: string): string => {
             // Implementation
             return "";
         };
-        
+
         const observedSupervisorAgent = observe({
             type: "agent",
             availableTools: ["search", "calculator"],

--- a/fern/docs/pages/llm-tracing/advanced-features/tags.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/tags.mdx
@@ -37,7 +37,7 @@ Tags are applied at the trace level, making them visible for all spans within th
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {5}
-            import { observe, updateCurrentTrace } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentTrace } from 'deepeval-ts/tracing';
             import OpenAI from 'openai';
 
             const llmApp = (query: string) => {

--- a/fern/docs/pages/llm-tracing/advanced-features/test-cases.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/test-cases.mdx
@@ -68,8 +68,8 @@ You can set span-level test case parameters in the `update_current_span` functio
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```js title="index.ts" {5}
-            import { observe, updateCurrentSpan } from "@deepeval-ts/tracing";
-            import { ToolCall } from "@deepeval-ts/test-case";
+            import { observe, updateCurrentSpan } from "deepeval-ts/tracing";
+            import { ToolCall } from "deepeval-ts";
 
             const toolCallingAgent = (query: string) => {
                 updateCurrentSpan({
@@ -125,7 +125,7 @@ You can set trace-level test case parameters in the `update_current_trace` funct
     <Tab title="TypeScript" language="typescript">
             ```js title="index.ts" {21}
             import OpenAI from "openai";
-            import { observe, updateCurrentTrace } from "@deepeval-ts/tracing";
+            import { observe, updateCurrentTrace } from "deepeval-ts/tracing";
 
             const client = new OpenAI();
 

--- a/fern/docs/pages/llm-tracing/advanced-features/threads.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/threads.mdx
@@ -20,19 +20,19 @@ You can use the `update_current_trace` function to set the `thread_id` within tr
             ```python title="main.py" {13}
             from deepeval.tracing import observe, update_current_trace
             from openai import OpenAI
-            
+
             client = OpenAI()
-            
+
             @observe()
             def llm_app(query: str):
                 res = client.chat.completions.create(
                     model="gpt-4o",
                     messages=[{"role": "user", "content": query}]
                 ).choices[0].message.content
-            
+
                 update_current_trace(thread_id="your-thread-id", input=query, output=res)
                 return res
-            
+
             llm_app("Write me a poem.")
             ```
 
@@ -41,16 +41,16 @@ You can use the `update_current_trace` function to set the `thread_id` within tr
     </Tab>
     <Tab title="TypeScript" language="typescript">
             ```typescript title="index.ts" {11}
-            import { observe, updateCurrentTrace } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentTrace } from 'deepeval-ts/tracing';
             import OpenAI from 'openai';
-            
+
             const llmApp = (query: string) => {
                 const openai = new OpenAI();
                 const res = openai.chat.completions.create({
                     model: "gpt-4o",
                     messages: [ { role: "user", content: query } ]
                 }).choices[0].message.content;
-                
+
                 updateCurrentTrace({ threadId: "your-thread-id", input: query, output: res });
                 return res;
             };

--- a/fern/docs/pages/llm-tracing/advanced-features/users.mdx
+++ b/fern/docs/pages/llm-tracing/advanced-features/users.mdx
@@ -17,19 +17,19 @@ You can track user interactions with your LLM app by setting the `user_id` in a 
             ```python title="main.py" {13}
             from deepeval.tracing import observe, update_current_trace
             from openai import OpenAI
-            
+
             client = OpenAI()
-            
+
             @observe()
             def llm_app(query: str):
                 res = client.chat.completions.create(
                     model="gpt-4o",
                     messages=[{"role": "user", "content": query}]
                 ).choices[0].message.content
-            
+
                 update_current_trace(user_id="your-user-id")
                 return res
-            
+
             llm_app("Write me a poem.")
             ```
 
@@ -41,7 +41,7 @@ You can track user interactions with your LLM app by setting the `user_id` in a 
         You can use the `updateCurrentTrace` function to set the `userId` within traces:
 
             ```typescript title="index.ts" {10}
-            import { observe, updateCurrentTrace } from '@deepeval-ts/tracing';
+            import { observe, updateCurrentTrace } from 'deepeval-ts/tracing';
             import OpenAI from 'openai';
 
             const llmApp = async (query: string) => {

--- a/fern/docs/pages/llm-tracing/latency-cost-tracking.mdx
+++ b/fern/docs/pages/llm-tracing/latency-cost-tracking.mdx
@@ -48,7 +48,7 @@ def generate_response(prompt: str) -> str:
 ```
 
 ```typescript {6,7,15,16}
-import { observe, updateLlmSpan } from "@deepeval-ts/tracing";
+import { observe, updateLlmSpan } from "deepeval-ts/tracing";
 
 const generateResponse = (prompt: string): string => {
   const output = "Generated response";
@@ -91,7 +91,7 @@ def generate_response(prompt: str) -> str:
 ```
 
 ```typescript {14}
-import { observe, updateCurrentSpan } from "@deepeval-ts/tracing";
+import { observe, updateCurrentSpan } from "deepeval-ts/tracing";
 
 const generateResponse = (prompt: string): string => {
   const output = "Generated response";
@@ -171,7 +171,7 @@ def generate_response(prompt: str) -> str:
 <Tab title="TypeScript">
 
 ```typescript title="index.ts" {14}
-import { observe, updateCurrentSpan } from "@deepeval-ts/tracing";
+import { observe, updateCurrentSpan } from "deepeval-ts/tracing";
 
 const generateResponse = (prompt: string): string => {
   const output = "Generated response";
@@ -237,7 +237,7 @@ def generate_response(prompt: str) -> str:
 <Tab title="TypeScript">
 
 ```typescript title="index.ts" {6,7,15,16}
-import { observe, updateLlmSpan } from "@deepeval-ts/tracing";
+import { observe, updateLlmSpan } from "deepeval-ts/tracing";
 
 const generateResponse = (prompt: string): string => {
   const output = "Generated response";

--- a/fern/docs/pages/llm-tracing/online-offline-evaluations.mdx
+++ b/fern/docs/pages/llm-tracing/online-offline-evaluations.mdx
@@ -66,7 +66,7 @@ You'll also need to use `update_current_span` with an `LLMTestCase` at runtime t
 
     <Tab title="TypeScript" language="typescript">
     ```typescript title="index.ts" {1,5,13}
-    import { observe, updateCurrentSpan } from '@deepeval-ts/tracing';
+    import { observe, updateCurrentSpan } from 'deepeval-ts/tracing';
 
     const generate = async (prompt: string): Promise<string> => {
     updateCurrentSpan({
@@ -132,7 +132,7 @@ Similar to evals for spans, you would also provide a `metricCollection` name, bu
 
     <Tab title="TypeScript" language="typescript">
     ```typescript title="index.ts" {5,13}
-    import { observe, updateCurrentTrace } from '@deepeval-ts/tracing';
+    import { observe, updateCurrentTrace } from 'deepeval-ts/tracing';
 
     const generate = async (prompt: string): Promise<string> => {
     updateCurrentTrace({

--- a/fern/docs/pages/llm-tracing/quickstart.mdx
+++ b/fern/docs/pages/llm-tracing/quickstart.mdx
@@ -157,7 +157,7 @@ In a later section, you'll learn how to create [spans that are LLM specific](/do
 
         <CodeBlocks>
           ```js title="In code"
-          import { traceManager } from '@deepeval-ts/tracing';
+          import { traceManager } from 'deepeval-ts/tracing';
 
           traceManager.configure({
               confidentApiKey: "YOUR-API-KEY"
@@ -174,7 +174,7 @@ In a later section, you'll learn how to create [spans that are LLM specific](/do
 
           ```ts title="index.ts" focus={2,13,16}
           import OpenAI from 'openai';
-          import { observe } from '@deepeval-ts/tracing';
+          import { observe } from 'deepeval-ts/tracing';
 
           const llmApp = async (query: string) => {
             const openai = new OpenAI();


### PR DESCRIPTION
Fixed & tested imports
```ts
import {
  observe,
  updateLlmSpan,
  updateCurrentSpan,
  updateCurrentTrace,
  updateRetrieverSpan,
  traceManager,
} from "deepeval-ts/tracing";

import {
  evaluate,
  ConversationalGolden,
  ConversationSimulator,
  ConversationalTestCase,
  EvaluationDataset,
  Golden,
  LLMTestCase,
  Prompt,
  Turn,
  ToolCall,
} from "deepeval-ts";

import { getCurrentSpan, getCurrentTrace } from "deepeval-ts/tracing";
import { sendAnnotation, AnnotationType } from "deepeval-ts";
```

Needs attentions (could be due to export missing):
```ts
import { getCurrentSpan, getCurrentTrace } from "deepeval-ts/tracing";
import { sendAnnotation, AnnotationType } from "deepeval-ts";
```