### PR TITLE
docs(fix): fix typo CONFIDENT_BROWSER_OPEN to CONFIDENT_OPEN_BROWSER

### DIFF
--- a/fern/docs/pages/llm-evaluation/multi-turn/end-to-end.mdx
+++ b/fern/docs/pages/llm-evaluation/multi-turn/end-to-end.mdx
@@ -106,7 +106,7 @@ Done ✅. You should see a link to your newly created sharable testing report.
 
 <Tip>
   `deepeval` opens your browser automatically by default. To disable this
-  behavior, set `CONFIDENT_BROWSER_OPEN=NO`.
+  behavior, set `CONFIDENT_OPEN_BROWSER=NO`.
 </Tip>
 
 <Frame caption="Multi-Turn Testing Reports">


### PR DESCRIPTION
The setting is called `CONFIDENT_OPEN_BROWSER` as per this snippet https://github.com/confident-ai/deepeval/blob/main/deepeval/config/settings.py#L170 

<img width="638" height="156" alt="image" src="https://github.com/user-attachments/assets/ebdc49ba-da4f-4284-86b1-397c6f976dd6" />
