### PR TITLE
docs: correct strict_mode score direction for higher-is-better metrics

### DIFF
--- a/fern/docs/pages/metrics/all-metrics/multi-turn/conversation-completeness.mdx
+++ b/fern/docs/pages/metrics/all-metrics/multi-turn/conversation-completeness.mdx
@@ -66,7 +66,7 @@ Here's a list of parameters you can configure when creating a `ConversationCompl
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/multi-turn/knowledge-retention.mdx
+++ b/fern/docs/pages/metrics/all-metrics/multi-turn/knowledge-retention.mdx
@@ -66,7 +66,7 @@ Here's a list of parameters you can configure when creating a `KnowledgeRetentio
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/multi-turn/role-adherence.mdx
+++ b/fern/docs/pages/metrics/all-metrics/multi-turn/role-adherence.mdx
@@ -69,7 +69,7 @@ Here's a list of parameters you can configure when creating a `RoleAdherenceMetr
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/multi-turn/turn-relevancy.mdx
+++ b/fern/docs/pages/metrics/all-metrics/multi-turn/turn-relevancy.mdx
@@ -70,7 +70,7 @@ Here's a list of parameters you can configure when creating a `TurnRelevancyMetr
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/answer-relevancy.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/answer-relevancy.mdx
@@ -67,7 +67,7 @@ Here's a list of parameters you can configure when creating a `AnswerRelevancyMe
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/contextual-precision.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/contextual-precision.mdx
@@ -78,7 +78,7 @@ Here's a list of parameters you can configure when creating a `ContextualPrecisi
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/contextual-recall.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/contextual-recall.mdx
@@ -70,7 +70,7 @@ Here's a list of parameters you can configure when creating a `ContextualRecallM
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/contextual-relevancy.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/contextual-relevancy.mdx
@@ -70,7 +70,7 @@ Here's a list of parameters you can configure when creating a `ContextualRelevan
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/faithfulness.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/faithfulness.mdx
@@ -69,7 +69,7 @@ Here's a list of parameters you can configure when creating a `FaithfulnessMetri
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/summarization.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/summarization.mdx
@@ -89,7 +89,7 @@ Here's a list of parameters you can configure when creating a `SummarizationMetr
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/task-completion.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/task-completion.mdx
@@ -60,7 +60,7 @@ Here's a list of parameters you can configure when creating a `TaskCompletionMet
   A boolean to enable concurrent execution within the `measure()` method.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.

--- a/fern/docs/pages/metrics/all-metrics/single-turn/tool-correctness.mdx
+++ b/fern/docs/pages/metrics/all-metrics/single-turn/tool-correctness.mdx
@@ -78,7 +78,7 @@ Here's a list of parameters you can configure when creating a `ToolCorrectnessMe
   A boolean to enable the inclusion a reason for its evaluation score.
 </ParamField>
 <ParamField path="strict_mode" type="boolean" default={"false"}>
-  A boolean to enforce a binary metric score: 0 for perfection, 1 otherwise.
+  A boolean to enforce a binary metric score: 1 for perfection, 0 otherwise.
 </ParamField>
 <ParamField path="verbose_mode" type="boolean" default={"false"}>
   A boolean to print the intermediate steps used to calculate the metric score.


### PR DESCRIPTION
These metric pages describe strict_mode as "0 for perfection, 1 otherwise", but for higher-is-better metrics strict_mode sets the threshold to 1, so a perfect run scores 1 (not 0). Flips the wording to "1 for perfection, 0 otherwise" to match the code and deepeval's own metric docs. Inverted metrics (hallucination, bias, toxicity, etc.) are intentionally left unchanged.